### PR TITLE
fix activate app

### DIFF
--- a/pyThings/things.py
+++ b/pyThings/things.py
@@ -38,14 +38,14 @@ def x_call_handler(obj):
 
     try:
         if obj.activate_app:
-            activate_app = "-activateApp YES"
+            activate_app = "YES"
         else:
-            activate_app = ""
+            activate_app = "NO"
     except: #pylint: disable=broad-except
         activate_app = ""
 
 
-    args = [ x_call_path, '-url', obj.callback_url, activate_app ]
+    args = [ x_call_path, '-url', obj.callback_url, "-activateApp", activate_app ]
 
     popen = subprocess.Popen(args, stdout=subprocess.PIPE)
     response_obj = json.loads(popen.stdout.read())


### PR DESCRIPTION

example of showing successfully showing an id from command line:
`/Applications/xcall.app/Contents/MacOS/xcall -url "things:///show?id=4BN9zXw1rcyf8wzV5rMP6F" -activateApp YES`


Requires YES to be an additional argument to the command line string:
```
['/Applications/xcall.app/Contents/MacOS/xcall', '-url', 'things:///add?&activate-app=False&title=A%20New%20Task', '-activateApp', 'YES']
['/Applications/xcall.app/Contents/MacOS/xcall', '-url', 'things:///add?&activate-app=False&title=A%20New%20Task', '-activateApp', 'NO']
```




